### PR TITLE
Support @hapi/joi: 16

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,9 +1,55 @@
 {
   "name": "joi-country-extension",
-  "version": "1.0.0",
+  "version": "1.3.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
+    "@hapi/address": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@hapi/address/-/address-2.1.2.tgz",
+      "integrity": "sha512-O4QDrx+JoGKZc6aN64L04vqa7e41tIiLU+OvKdcYaEMP97UttL0f9GIi9/0A4WAMx0uBd6SidDIhktZhgOcN8Q==",
+      "dev": true
+    },
+    "@hapi/formula": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@hapi/formula/-/formula-1.2.0.tgz",
+      "integrity": "sha512-UFbtbGPjstz0eWHb+ga/GM3Z9EzqKXFWIbSOFURU0A/Gku0Bky4bCk9/h//K2Xr3IrCfjFNhMm4jyZ5dbCewGA==",
+      "dev": true
+    },
+    "@hapi/hoek": {
+      "version": "8.5.0",
+      "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-8.5.0.tgz",
+      "integrity": "sha512-7XYT10CZfPsH7j9F1Jmg1+d0ezOux2oM2GfArAzLwWe4mE2Dr3hVjsAL6+TFY49RRJlCdJDMw3nJsLFroTc8Kw==",
+      "dev": true
+    },
+    "@hapi/joi": {
+      "version": "16.1.7",
+      "resolved": "https://registry.npmjs.org/@hapi/joi/-/joi-16.1.7.tgz",
+      "integrity": "sha512-anaIgnZhNooG3LJLrTFzgGALTiO97zRA1UkvQHm9KxxoSiIzCozB3RCNCpDnfhTJD72QlrHA8nwGmNgpFFCIeg==",
+      "dev": true,
+      "requires": {
+        "@hapi/address": "^2.1.2",
+        "@hapi/formula": "^1.2.0",
+        "@hapi/hoek": "^8.2.4",
+        "@hapi/pinpoint": "^1.0.2",
+        "@hapi/topo": "^3.1.3"
+      }
+    },
+    "@hapi/pinpoint": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@hapi/pinpoint/-/pinpoint-1.0.2.tgz",
+      "integrity": "sha512-dtXC/WkZBfC5vxscazuiJ6iq4j9oNx1SHknmIr8hofarpKUZKmlUVYVIhNVzIEgK5Wrc4GMHL5lZtt1uS2flmQ==",
+      "dev": true
+    },
+    "@hapi/topo": {
+      "version": "3.1.6",
+      "resolved": "https://registry.npmjs.org/@hapi/topo/-/topo-3.1.6.tgz",
+      "integrity": "sha512-tAag0jEcjwH+P2quUfipd7liWCNX2F8NvYjQp2wtInsZxnMlypdw0FtAOLxtvvkO+GSRRbmNi8m/5y42PQJYCQ==",
+      "dev": true,
+      "requires": {
+        "@hapi/hoek": "^8.3.0"
+      }
+    },
     "assertion-error": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.1.0.tgz",
@@ -156,12 +202,6 @@
       "integrity": "sha1-k0EP0hsAlzUVH4howvJx80J+I/0=",
       "dev": true
     },
-    "hoek": {
-      "version": "5.0.3",
-      "resolved": "https://registry.npmjs.org/hoek/-/hoek-5.0.3.tgz",
-      "integrity": "sha512-Bmr56pxML1c9kU+NS51SMFkiVQAb+9uFfXwyqR2tn4w2FPvmPt65eZ9aCcEfRXd9G74HkZnILC6p967pED4aiw==",
-      "dev": true
-    },
     "i18n-iso-countries": {
       "version": "3.7.5",
       "resolved": "https://registry.npmjs.org/i18n-iso-countries/-/i18n-iso-countries-3.7.5.tgz",
@@ -182,26 +222,6 @@
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
       "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
       "dev": true
-    },
-    "isemail": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/isemail/-/isemail-3.1.2.tgz",
-      "integrity": "sha512-zfRhJn9rFSGhzU5tGZqepRSAj3+g6oTOHxMGGriWNJZzyLPUK8H7VHpqKntegnW8KLyGA9zwuNaCoopl40LTpg==",
-      "dev": true,
-      "requires": {
-        "punycode": "2.x.x"
-      }
-    },
-    "joi": {
-      "version": "13.1.2",
-      "resolved": "https://registry.npmjs.org/joi/-/joi-13.1.2.tgz",
-      "integrity": "sha512-bZZSQYW5lPXenOfENvgCBPb9+H6E6MeNWcMtikI04fKphj5tvFL9TOb+H2apJzbCrRw/jebjTH8z6IHLpBytGg==",
-      "dev": true,
-      "requires": {
-        "hoek": "5.x.x",
-        "isemail": "3.x.x",
-        "topo": "3.x.x"
-      }
     },
     "json3": {
       "version": "3.3.2",
@@ -348,12 +368,6 @@
       "integrity": "sha1-uULm1L3mUwBe9rcTYd74cn0GReA=",
       "dev": true
     },
-    "punycode": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.0.tgz",
-      "integrity": "sha1-X4Y+3Im5bbCQdLrXlHvwkFbKTn0=",
-      "dev": true
-    },
     "supports-color": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.1.2.tgz",
@@ -361,15 +375,6 @@
       "dev": true,
       "requires": {
         "has-flag": "^1.0.0"
-      }
-    },
-    "topo": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/topo/-/topo-3.0.0.tgz",
-      "integrity": "sha512-Tlu1fGlR90iCdIPURqPiufqAlCZYzLjHYVVbcFWDMcX7+tK8hdZWAfsMrD/pBul9jqHHwFjNdf1WaxA9vTRRhw==",
-      "dev": true,
-      "requires": {
-        "hoek": "5.x.x"
       }
     },
     "type-detect": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "joi-country-extension",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "description": "A Joi extension for validation of ISO 3166-1 alpha-2 country codes",
   "homepage": "https://tallysticks.io",
   "bugs": {
@@ -32,6 +32,6 @@
     "chai": "^4.1.2",
     "chai-as-promised": "^7.1.1",
     "mocha": "^3.5.3",
-    "joi": "^13.1.1"
+    "@hapi/joi": "16.1.7"
   }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -5,26 +5,15 @@ const countries = require('i18n-iso-countries')
 module.exports = joi => {
   return {
     base: joi.string(),
-    name: 'string',
-    language: {
-      IsoCountryInvalidFormat: 'needs to be a valid ISO 3166-1 alpha-2 country code',
+    type: 'country',
+    messages: {
+      'country.base': '"value" needs to be a valid ISO 3166-1 alpha-2 country code',
     },
-    pre(value, state, options) {
-      return value
+    validate(value, helpers) {
+      if (countries.isValid(value)) {
+        return { value: value.toUpperCase() }
+      }
+      return { value, errors: helpers.error('country.base') };
     },
-    rules: [
-      {
-        name: 'country',
-        setup(params) {
-          this._flags.country = true
-        },
-        validate(params, value, state, options) {
-          if (countries.isValid(value)) {
-            return value.toUpperCase()
-          }
-          return this.createError('string.IsoCountryInvalidFormat', { value }, state, options)
-        },
-      },
-    ],
   }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -7,7 +7,7 @@ module.exports = joi => {
     base: joi.string(),
     type: 'country',
     messages: {
-      'country.base': '"value" needs to be a valid ISO 3166-1 alpha-2 country code',
+      'country.base': '"{{#label}}" needs to be a valid ISO 3166-1 alpha-2 country code',
     },
     validate(value, helpers) {
       if (countries.isValid(value)) {

--- a/test/index.js
+++ b/test/index.js
@@ -4,7 +4,7 @@
 
 const { should } = require('chai').use(require('chai-as-promised'))
 
-const BaseJoi = require('joi')
+const BaseJoi = require('@hapi/joi')
 const JoiCountryExtension = require('../src')
 
 const Joi = BaseJoi.extend(JoiCountryExtension)
@@ -16,26 +16,26 @@ describe('Joi Country Extension', () => {
   })
 
   it(`should pass validation if valid IMO number provided`, async () => {
-    const schema = Joi.string().country()
-    const result = await schema.validate('GB').should.be.fulfilled
+    const schema = Joi.country()
+    const result = await schema.validateAsync('GB').should.be.fulfilled
     result.should.be.equal('GB')
   })
 
   it(`should fail validation if IMO number provided without the 'IMO' prefix`, async () => {
-    const schema = Joi.string().country()
-    const result = await schema.validate('de').should.be.fulfilled
+    const schema = Joi.country()
+    const result = await schema.validateAsync('de').should.be.fulfilled
     result.should.be.equal('DE')
   })
 
   it(`should fail validation if invalid string is provided`, async () => {
-    const schema = Joi.string().country()
-    const error = await schema.validate('Denmark').should.be.rejected
+    const schema = Joi.country()
+    const error = await schema.validateAsync('Denmark').should.be.rejected
     error.message.should.equal('"value" needs to be a valid ISO 3166-1 alpha-2 country code')
   })
 
   it(`should fail validation if IMO number is not provided as a string`, async () => {
-    const schema = Joi.string().country()
-    const error = await schema.validate(123).should.be.rejected
+    const schema = Joi.country()
+    const error = await schema.validateAsync(123).should.be.rejected
     error.message.should.equal('"value" must be a string')
   })
 


### PR DESCRIPTION
Support @hapi/joi: 16.1.7's new `extend`.

## Changes

1. Update to support new Joi's new `extend`.
1. Bump version to 1.3.0.